### PR TITLE
Replace dots with slashes when concatenating resource paths

### DIFF
--- a/Internal/UI/ColorPicker.lua
+++ b/Internal/UI/ColorPicker.lua
@@ -28,6 +28,7 @@ local ceil = math.ceil
 local max = math.max
 local min = math.min
 local insert = table.insert
+local gsub = string.gsub
 
 local Button = require(SLAB_PATH .. '.Internal.UI.Button')
 local Cursor = require(SLAB_PATH .. '.Internal.Core.Cursor')
@@ -422,7 +423,7 @@ function ColorPicker.Begin(Options)
 	local ColorW = (WinX + WinW) - ColorX
 	Cursor.SetPosition(ColorX, Y)
 	Image.Begin('ColorPicker_CurrentAlpha', {
-		Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
+		Path = gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
 		SubW = ColorW,
 		SubH = ColorH,
 		WrapH = "repeat",
@@ -438,7 +439,7 @@ function ColorPicker.Begin(Options)
 
 	Cursor.SetPosition(ColorX, Y)
 	Image.Begin('ColorPicker_CurrentAlpha', {
-		Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
+		Path = gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
 		SubW = ColorW,
 		SubH = ColorH,
 		WrapH = "repeat",

--- a/Internal/UI/ColorPicker.lua
+++ b/Internal/UI/ColorPicker.lua
@@ -422,7 +422,7 @@ function ColorPicker.Begin(Options)
 	local ColorW = (WinX + WinW) - ColorX
 	Cursor.SetPosition(ColorX, Y)
 	Image.Begin('ColorPicker_CurrentAlpha', {
-		Path = SLAB_PATH .. "/Internal/Resources/Textures/Transparency.png",
+		Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
 		SubW = ColorW,
 		SubH = ColorH,
 		WrapH = "repeat",
@@ -438,7 +438,7 @@ function ColorPicker.Begin(Options)
 
 	Cursor.SetPosition(ColorX, Y)
 	Image.Begin('ColorPicker_CurrentAlpha', {
-		Path = SLAB_PATH .. "/Internal/Resources/Textures/Transparency.png",
+		Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Transparency.png",
 		SubW = ColorW,
 		SubH = ColorH,
 		WrapH = "repeat",

--- a/Internal/UI/Dialog.lua
+++ b/Internal/UI/Dialog.lua
@@ -117,7 +117,7 @@ local function FileDialogItem(Id, Label, IsDirectory, Index)
 	ListBox.BeginItem(Id, {Selected = Utility.HasValue(ActiveInstance.Selected, Index)})
 
 	if IsDirectory then
-		Image.Begin('FileDialog_Folder', {Path = SLAB_PATH .. "/Internal/Resources/Textures/Folder.png"})
+		Image.Begin('FileDialog_Folder', {Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Folder.png"})
 		Cursor.SameLine({CenterY = true})
 	end
 

--- a/Internal/UI/Dialog.lua
+++ b/Internal/UI/Dialog.lua
@@ -29,6 +29,7 @@ local remove = table.remove
 local min = math.min
 local max = math.max
 local floor = math.floor
+local gsub = string.gsub
 
 local Button = require(SLAB_PATH .. '.Internal.UI.Button')
 local ComboBox = require(SLAB_PATH .. '.Internal.UI.ComboBox')
@@ -117,7 +118,7 @@ local function FileDialogItem(Id, Label, IsDirectory, Index)
 	ListBox.BeginItem(Id, {Selected = Utility.HasValue(ActiveInstance.Selected, Index)})
 
 	if IsDirectory then
-		Image.Begin('FileDialog_Folder', {Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Folder.png"})
+		Image.Begin('FileDialog_Folder', {Path = gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/Folder.png"})
 		Cursor.SameLine({CenterY = true})
 	end
 

--- a/SlabDebug.lua
+++ b/SlabDebug.lua
@@ -312,7 +312,7 @@ local function DrawStyleEditor()
 		local Type = Style_FileDialog == 'new' and 'savefile' or Style_FileDialog == 'load' and 'openfile' or nil
 
 		if Type ~= nil then
-			local Path = love.filesystem.getRealDirectory(SLAB_PATH) .. "/" .. SLAB_PATH .. "Internal/Resources/Styles"
+			local Path = string.gsub(SLAB_PATH, "%.", "/") .. "Internal/Resources/Styles"
 			local Result = Slab.FileDialog({AllowMultiSelect = false, Directory = Path, Type = Type, Filters = {{"*.style", "Styles"}}})
 
 			if Result.Button ~= "" then

--- a/SlabTest.lua
+++ b/SlabTest.lua
@@ -544,8 +544,9 @@ local function DrawInput()
 	end
 end
 
-local DrawImage_Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/power.png"
-local DrawImage_Path_Icons = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Textures/gameicons.png"
+local SlabPathAsDirectory = string.gsub(SLAB_PATH, "%.", "/")
+local DrawImage_Path = SlabPathAsDirectory .. "/Internal/Resources/Textures/power.png"
+local DrawImage_Path_Icons = SlabPathAsDirectory .. "/Internal/Resources/Textures/gameicons.png"
 local DrawImage_Color = {1, 0, 0, 1}
 local DrawImage_Color_Edit = false
 local DrawImage_Scale = 1.0
@@ -859,7 +860,7 @@ local function DrawListBox()
 	Slab.EndListBox()
 end
 
-local DrawTree_Icon_Path = SLAB_PATH .. "/Internal/Resources/Textures/Folder.png"
+local DrawTree_Icon_Path = SlabPathAsDirectory .. "/Internal/Resources/Textures/Folder.png"
 local DrawTree_Opened_Selected = 1
 
 local function DrawTree()
@@ -1727,7 +1728,7 @@ local DrawTooltip_CheckBox = false
 local DrawTooltip_Radio = 1
 local DrawTooltip_ComboBox_Items = {"Button", "Check Box", "Combo Box", "Image", "Input", "Text", "Tree"}
 local DrawTooltip_ComboBox_Selected = "Button"
-local DrawTooltip_Image = SLAB_PATH .. "/Internal/Resources/Textures/power.png"
+local DrawTooltip_Image = SlabPathAsDirectory .. "/Internal/Resources/Textures/power.png"
 local DrawTooltip_Input = "This is an input box."
 
 local function DrawTooltip()
@@ -1989,7 +1990,7 @@ local function DrawLayout()
 end
 
 local DrawFonts_Roboto = nil
-local DrawFonts_Roboto_Path = string.gsub(SLAB_PATH, "%.", "/") .. "/Internal/Resources/Fonts/Roboto-Regular.ttf"
+local DrawFonts_Roboto_Path = SlabPathAsDirectory .. "/Internal/Resources/Fonts/Roboto-Regular.ttf"
 
 local function DrawFonts()
 	if DrawFonts_Roboto == nil then


### PR DESCRIPTION
Calling FileDialog from Slab locating at a subfolder raises error:

> Error
> 
> libs/Slab/Internal/UI/Image.lua:42: Could not open file libs.Slab/Internal/Resources/Textures/Folder.png. Does not exist.
> 
> 
> Traceback
> 
> [C]: in function 'newImage'
> libs/Slab/Internal/UI/Image.lua:42: in function 'GetImage'
> libs/Slab/Internal/UI/Image.lua:82: in function 'Begin'
> libs/Slab/Internal/UI/Dialog.lua:120: in function 'FileDialogItem'
> libs/Slab/Internal/UI/Dialog.lua:506: in function 'FileDialog'

And at `Dialog.lua:120`:

```lua
Image.Begin('FileDialog_Folder', {Path = SLAB_PATH .. "/Internal/Resources/Textures/Folder.png"})
```

where `SLAB_PATH` is `"libs.Slab"`.

I searched all occurances of `SLAB_PATH` and found this: (At `Style.lua:81`)

```lua
local StylePath = "/Internal/Resources/Styles/"
local Path = SLAB_PATH .. StylePath
Path = string.gsub(Path, "%.", "/")
```

Imitaing this, I fixed all similar concatenatings with `gsub` and made this PR.