### PR TITLE
Add IsAnyInputFocused

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1021,6 +1021,17 @@ function Slab.IsInputFocused(Id)
 end
 
 --[[
+	IsAnyInputFocused
+
+	Returns whether any input control is focused or not.
+
+	Return: [Boolean] True if there is an input control focused. False otherwise.
+--]]
+function Slab.IsAnyInputFocused()
+	return Input.IsAnyFocused()
+end
+
+--[[
 	SetInputFocus
 
 	Sets the focus of the input control to the control with the given Id. The focus is set at the beginning

--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -1384,6 +1384,10 @@ function Input.GetCursorPos()
 	return 0, 0, 0
 end
 
+function Input.IsAnyFocused()
+	return Focused ~= nil
+end
+
 function Input.IsFocused(Id)
 	local Instance = GetInstance(Window.GetId() .. '.' .. Id)
 	return Instance == Focused

--- a/main.lua
+++ b/main.lua
@@ -27,6 +27,8 @@ SOFTWARE.
 local Slab = require 'Slab'
 local SlabTest = require 'SlabTest'
 
+local TypedText = 'Typed outside of Slab: '
+
 function love.load(args)
 	love.graphics.setBackgroundColor(0.4, 0.88, 1.0)
 	Slab.Initialize(args)
@@ -37,6 +39,15 @@ function love.update(dt)
 	SlabTest.Begin()
 end
 
+function love.textinput(InputText)
+    if not Slab.IsAnyInputFocused() then
+		TypedText = TypedText .. InputText
+    end
+end
+
 function love.draw()
 	Slab.Draw()
+
+	love.graphics.setColor(0,0,0,1)
+	love.graphics.print(TypedText, 20, love.graphics.getHeight()-20)
 end


### PR DESCRIPTION
IsAnyInputFocused allows you to avoid accepting gameplay input while
slab is focused.

This check seems pretty essential so your game doesn't execute actions
in the background while you type into slab. Makes slab feel more modal
but give user complete control.

Add example to main.