### PR TITLE
Fix missing Step argument to InputNumberDrag

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1016,6 +1016,7 @@ function Slab.InputNumberDrag(Id, Value, Min, Max, Step, Options)
 	Options.Text = tostring(Value)
 	Options.MinNumber = Min
 	Options.MaxNumber = Max
+	Options.Step = Step
 	Options.NumbersOnly = true
 	Options.UseSlider = false
 	Options.NoDrag = false

--- a/SlabTest.lua
+++ b/SlabTest.lua
@@ -526,14 +526,14 @@ local function DrawInput()
 
 	Slab.Text("Min")
 	Slab.SameLine()
-	if Slab.InputNumberDrag('DrawInput_Basic_Numbers_Slider_Min', DrawInput_Basic_Numbers_Slider_Min, nil, DrawInput_Basic_Numbers_Slider_Max, {W = 50}) then
+	if Slab.InputNumberDrag('DrawInput_Basic_Numbers_Slider_Min', DrawInput_Basic_Numbers_Slider_Min, nil, DrawInput_Basic_Numbers_Slider_Max, 0.1, {W = 50}) then
 		DrawInput_Basic_Numbers_Slider_Min = Slab.GetInputNumber()
 	end
 
 	Slab.SameLine()
 	Slab.Text("Max")
 	Slab.SameLine()
-	if Slab.InputNumberDrag('DrawInput_Basic_Numbers_Slider_Max', DrawInput_Basic_Numbers_Slider_Max, DrawInput_Basic_Numbers_Slider_Min, nil, {W = 50}) then
+	if Slab.InputNumberDrag('DrawInput_Basic_Numbers_Slider_Max', DrawInput_Basic_Numbers_Slider_Max, DrawInput_Basic_Numbers_Slider_Min, nil, 0.1, {W = 50}) then
 		DrawInput_Basic_Numbers_Slider_Max = Slab.GetInputNumber()
 	end
 


### PR DESCRIPTION
Step argument was unhandled in InputNumberDrag and unpassed in SlabTest.

Test: changing the value in SlabTest from 0.01 to 1 has a clear effect on the input control.