### PR TITLE
Add Options and Fallback arguments to Properties

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1403,27 +1403,39 @@ end
 	TODO: Iterate through nested tables.
 
 	Table: [Table] The list of properties to build widgets for.
+	Options: [Table] An optional table of Options for each key in Table. The special key '*' can be set as a
+		fallback set of Options.
+	Fallback: [Table] An optional table of Options used for any key not found in Options.
 
 	Return: None.
 --]]
-function Slab.Properties(Table)
+function Slab.Properties(Table, Options, Fallback)
 	if Table ~= nil then
 		for K, V in pairs(Table) do
 			local Type = type(V)
+			local Opt = (Options and Options[K]) or Fallback or {}
 			if Type == "boolean" then
-				if Slab.CheckBox(V, K) then
+				if Slab.CheckBox(V, K, Opt) then
 					Table[K] = not Table[K]
 				end
 			elseif Type == "number" then
 				Slab.Text(K .. ": ")
 				Slab.SameLine()
-				if Slab.Input(K, {Text = tostring(V), NumbersOnly = true, ReturnOnText = false}) then
+				Opt.Text = tostring(V)
+				Opt.NumbersOnly = true
+				Opt.ReturnOnText = false
+				if Opt.UseSlider == nil then
+					Opt.UseSlider = Opt.MinNumber and Opt.MinNumber
+				end
+				if Slab.Input(K, Opt) then
 					Table[K] = Slab.GetInputNumber()
 				end
 			elseif Type == "string" then
 				Slab.Text(K .. ": ")
 				Slab.SameLine()
-				if Slab.Input(K, {Text = V, ReturnOnText = false}) then
+				Opt.Text = V
+				Opt.ReturnOnText = false
+				if Slab.Input(K, Opt) then
 					Table[K] = Slab.GetInputText()
 				end
 			end


### PR DESCRIPTION
Add optional Options and Fallback arguments that lets you customize each
property or use default options for multiple properties.

Instead of defining options for every parameter, it's often convenient
to define it once. Alternative implementation is a fallback key in
Options but that risks that the user picks that key.

This gives you access to slider widgets, limits, etc:

    Slab.Properties(trails, {
        -- integers
        history       = {MinNumber = trails.display, MaxNumber = 1000},
        display       = {MinNumber = 0,              MaxNumber = trails.history},
        -- floats
        initial_scale = {MinNumber = 0.001,          MaxNumber = 5},
        scale_down    = {MinNumber = 0.001,          MaxNumber = 1},
        alpha         = {MinNumber = 0.001,          MaxNumber = 1},
    },
                        {MinNumber = -200.1,         MaxNumber = 200})

Or alternatively:

    Slab.Properties(trails, nil,
                        {MinNumber = -200.1,         MaxNumber = 200})

Test:
paste the above Properties uses in SlabTest and add to the top of the file:

```lua
local trails = {
	history = 30,
	display = 21,
	initial_scale = 2.1,
	scale_down = 0.96,
	alpha = 0.5,
	beta = 0.5,
	kappa = 5,
}
```

