### PR TITLE
Add support for ReturnOnText to sliders (WIP)

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1019,7 +1019,7 @@ function Slab.InputNumberDrag(Id, Value, Min, Max, Step, Options)
 	Options.NumbersOnly = true
 	Options.UseSlider = false
 	Options.NoDrag = false
-	Options.ReturnOnText = false
+	-- Options.ReturnOnText = false
 	return Slab.Input(Id, Options)
 end
 
@@ -1046,7 +1046,7 @@ function Slab.InputNumberSlider(Id, Value, Min, Max, Options)
 	Options.MaxNumber = Max
 	Options.NumbersOnly = true
 	Options.UseSlider = true
-	Options.ReturnOnText = false
+	-- Options.ReturnOnText = false
 	return Slab.Input(Id, Options)
 end
 

--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -825,10 +825,15 @@ local function UpdateSlider(Instance)
 		local Max = Instance.MaxNumber == nil and huge or Instance.MaxNumber
 		local IsInteger = floor(Min) == Min and floor(Max) == Max
 		local Value = (Max - Min) * Ratio + Min
-		if IsInteger then
-			Instance.Text = string.format("%d", Value)
-		else
-			Instance.Text = string.format("%.3f", Value)
+		local OldText = Instance.Text
+		-- if IsInteger then
+		-- 	Instance.Text = string.format("%d", Value)
+		-- else
+		-- 	Instance.Text = string.format("%.3f", Value)
+		-- end
+		Instance.Text = tostring(Value)
+		if Instance.Text ~= OldText then
+			Instance.TextChanged = true
 		end
 	end
 end
@@ -842,6 +847,7 @@ local function UpdateDrag(Instance, Step)
 				Value = Value + Step * DeltaX
 				Instance.Text = tostring(Value)
 				ValidateNumber(Instance)
+				Instance.TextChanged = true
 			end
 		end
 	end


### PR DESCRIPTION
Not ready for merge. This PR contains a commit that should probably be split into two. The first change is to allow ReturnOnText for sliders. The control will return true if there was any change to the text content while sliding. The second change disables the conditional formatting for integers, because it broke non-integer inputs with limits 0 to 1. Maybe a better change would be to make IsInteger a proper option?