### PR TITLE
Add support for ReturnOnText to sliders

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1019,7 +1019,6 @@ function Slab.InputNumberDrag(Id, Value, Min, Max, Step, Options)
 	Options.NumbersOnly = true
 	Options.UseSlider = false
 	Options.NoDrag = false
-	Options.ReturnOnText = false
 	return Slab.Input(Id, Options)
 end
 
@@ -1046,7 +1045,6 @@ function Slab.InputNumberSlider(Id, Value, Min, Max, Options)
 	Options.MaxNumber = Max
 	Options.NumbersOnly = true
 	Options.UseSlider = true
-	Options.ReturnOnText = false
 	return Slab.Input(Id, Options)
 end
 

--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -825,10 +825,14 @@ local function UpdateSlider(Instance)
 		local Max = Instance.MaxNumber == nil and huge or Instance.MaxNumber
 		local IsInteger = floor(Min) == Min and floor(Max) == Max
 		local Value = (Max - Min) * Ratio + Min
+		local OldText = Instance.Text
 		if IsInteger then
 			Instance.Text = string.format("%d", Value)
 		else
 			Instance.Text = string.format("%.3f", Value)
+		end
+		if Instance.Text ~= OldText then
+			Instance.TextChanged = true
 		end
 	end
 end
@@ -842,6 +846,7 @@ local function UpdateDrag(Instance, Step)
 				Value = Value + Step * DeltaX
 				Instance.Text = tostring(Value)
 				ValidateNumber(Instance)
+				Instance.TextChanged = true
 			end
 		end
 	end


### PR DESCRIPTION
Allow ReturnOnText for slider inputs. The control will return true if
there was any change to the text content while sliding.