### PR TITLE
Allow to title file dialogs via Title field

### DIFF
--- a/Internal/UI/Dialog.lua
+++ b/Internal/UI/Dialog.lua
@@ -409,14 +409,14 @@ function Dialog.FileDialog(Options)
 	Options.AllowMultiSelect = Options.AllowMultiSelect == nil and true or Options.AllowMultiSelect
 	Options.Directory = Options.Directory == nil and nil or Options.Directory
 	Options.Type = Options.Type == nil and 'openfile' or Options.Type
+	Options.Title = Options.Title == "File dialog" or Options.Title
 	Options.Filters = Options.Filters == nil and {{"*.*", "All Files"}} or Options.Filters
 
-	local Title = "Open File"
 	if Options.Type == 'savefile' then
 		Options.AllowMultiSelect = false
-		Title = "Save File"
+		if not Options.Title then Options.Title = "Save File" end
 	elseif Options.Type == 'opendirectory' then
-		Title = "Open Directory"
+		if not Options.Title then Options.Title = "Open Directory" end
 	end
 
 	local Result = {Button = "", Files = {}}
@@ -426,7 +426,7 @@ function Dialog.FileDialog(Options)
 	local W = love.graphics.getWidth() * 0.65
 	local H = love.graphics.getHeight() * 0.65
 	if Dialog.Begin('FileDialog', {
-		Title = Title,
+		Title = Options.Title,
 		AutoSizeWindow = false,
 		W = W,
 		H = H,


### PR DESCRIPTION
Feature for adding Title in file dialogs like in OS-native dialogs
```local result = slab.FileDialog({Type = "savefile", Title = "Save map"})```

![File dialog](https://i.imgur.com/po7s96J.png)