### PR TITLE
Allow ContextMenuItem to be opened on left click

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -695,11 +695,13 @@ end
 			Slab.EndContextMenu()
 		end
 
+	OnLeftClick: [Boolean] if true, the menu will open when left-clicking. Default is right click.
+
 	Return: [Boolean] Returns true if the user right clicks on the previous item call. EndContextMenu must be called in order for
 		this to function properly.
 --]]
-function Slab.BeginContextMenuItem()
-	return Menu.BeginContextMenu({IsItem = true})
+function Slab.BeginContextMenuItem(OnLeftClick)
+	return Menu.BeginContextMenu({IsItem = true, OnLeftClick = OnLeftClick or false})
 end
 
 --[[

--- a/Internal/UI/Menu.lua
+++ b/Internal/UI/Menu.lua
@@ -267,7 +267,8 @@ function Menu.BeginContextMenu(Options)
 	end
 
 	local IsOpening = false
-	if not Window.IsObstructedAtMouse() and Window.IsMouseHovered() and Mouse.IsClicked(2) then
+	local MouseIdx = Options.OnLeftClick and 1 or 2
+	if not Window.IsObstructedAtMouse() and Window.IsMouseHovered() and Mouse.IsClicked(MouseIdx) then
 		local IsValidWindow = Options.IsWindow and Window.GetHotItem() == nil
 		local IsValidItem = Options.IsItem
 


### PR DESCRIPTION
This PR adds a new option for ContextMenuItem, allowing to show the menu when left-clicking instead of right-clicking. This is useful to have buttons which exclusively open a context menu, such as the three dots menu on Android.