### PR TITLE
Fixed OnMouseMoved not calling MouseMovedFn

### DIFF
--- a/Internal/Input/Mouse.lua
+++ b/Internal/Input/Mouse.lua
@@ -54,6 +54,10 @@ local function OnMouseMoved(X, Y, DX, DY, IsTouch)
 	State.Y = Y
 	State.AsyncDeltaX = State.AsyncDeltaX + DX
 	State.AsyncDeltaY = State.AsyncDeltaY + DY
+
+	if MouseMovedFn ~= nil then
+		MouseMovedFn(X, Y, DX, DY, IsTouch)
+	end
 end
 
 local function PushEvent(Type, X, Y, Button, IsTouch, Presses)


### PR DESCRIPTION
`OnMouseMoved` in `Mouse.lua` was not alling `MouseMovedFn` so my defined `love.mousemoved` was not being called.

My editor helped me spot this straight away and it was a simple fix so I made a PR for it.