### PR TITLE
Fix Window ResetLayout not resetting Size

### DIFF
--- a/Internal/UI/Window.lua
+++ b/Internal/UI/Window.lua
@@ -678,7 +678,7 @@ function Window.Begin(Id, Options)
 		NoOutline = Options.NoOutline
 	})
 
-	if Options.ResetSize then
+	if Options.ResetSize or Options.ResetLayout then
 		ActiveInstance.SizeDeltaX = 0.0
 		ActiveInstance.SizeDeltaY = 0.0
 	end


### PR DESCRIPTION
The docs mention that `ResetLayout` resets the Size of the window, but it does not.
This PR should fix that, simple fix.