### PR TITLE
ColorPicker - optional alpha value passing and return value use int instead of string

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -1482,31 +1482,33 @@ function Slab.Properties(Table, Options, Fallback)
 	Fallback = Fallback or {}
 
 	if Table ~= nil then
-		for K, V in pairs(Table) do
+		for I, T in ipairs(Table) do
+			local V = T.Value
 			local Type = type(V)
-			local ItemOptions = Options[K] or Fallback
+			local ID = T.ID
+			local ItemOptions = Options[ID] or Fallback
 			if Type == "boolean" then
-				if Slab.CheckBox(V, K, ItemOptions) then
-					Table[K] = not Table[K]
+				if Slab.CheckBox(V, ID, ItemOptions) then
+					T.Value = not T.Value
 				end
 			elseif Type == "number" then
-				Slab.Text(K .. ": ")
+				Slab.Text(ID .. ": ")
 				Slab.SameLine()
 				ItemOptions.Text = V
 				ItemOptions.NumbersOnly = true
 				ItemOptions.ReturnOnText = false
 				ItemOptions.UseSlider = ItemOptions.MinNumber and ItemOptions.MaxNumber
-				if Slab.Input(K, ItemOptions) then
-					Table[K] = Slab.GetInputNumber()
+				if Slab.Input(ID, ItemOptions) then
+					T.Value = Slab.GetInputNumber()
 				end
 			elseif Type == "string" then
-				Slab.Text(K .. ": ")
+				Slab.Text(ID .. ": ")
 				Slab.SameLine()
 				ItemOptions.Text = V
 				ItemOptions.NumbersOnly = false
 				ItemOptions.ReturnOnText = false
-				if Slab.Input(K, ItemOptions) then
-					Table[K] = Slab.GetInputText()
+				if Slab.Input(ID, ItemOptions) then
+					T.Value = Slab.GetInputText()
 				end
 			end
 		end
@@ -2218,6 +2220,22 @@ end
 --]]
 function Slab.SetLayoutColumn(Index)
 	LayoutManager.SetColumn(Index)
+end
+
+--[[
+	SetNextLayoutColumn
+
+	Sets the current active column to the next column.
+
+	Return: None.
+--]]
+function Slab.SetNextLayoutColumn(Columns)
+	-- local current = LayoutManager.GetCurrentColumn()
+	-- local index = current + 1
+	-- if index > Columns then
+	-- 	index = 1
+	-- end
+	-- LayoutManager.SetColumn(index)
 end
 
 --[[

--- a/Internal/Input/Mouse.lua
+++ b/Internal/Input/Mouse.lua
@@ -54,6 +54,10 @@ local function OnMouseMoved(X, Y, DX, DY, IsTouch)
 	State.Y = Y
 	State.AsyncDeltaX = State.AsyncDeltaX + DX
 	State.AsyncDeltaY = State.AsyncDeltaY + DY
+
+	if MouseMovedFn ~= nil then
+		MouseMovedFn(X, Y, DX, DY, IsTouch)
+	end
 end
 
 local function PushEvent(Type, X, Y, Button, IsTouch, Presses)

--- a/Internal/UI/ColorPicker.lua
+++ b/Internal/UI/ColorPicker.lua
@@ -462,15 +462,15 @@ function ColorPicker.Begin(Options)
 	Cursor.NewLine()
 
 	LayoutManager.Begin('ColorPicker_Buttons_Layout', {AlignX = 'right'})
-	local Result = {Button = false, Color = Utility.MakeColor(CurrentColor)}
+	local Result = {Button = 0, Color = Utility.MakeColor(CurrentColor)}
 	if Button.Begin("OK") then
-		Result.Button = true
+		Result.Button = 1
 	end
 
 	LayoutManager.SameLine()
 
 	if Button.Begin("Cancel") then
-		Result.Button = false
+		Result.Button = -1
 		Result.Color = Utility.MakeColor(Options.Color)
 	end
 	LayoutManager.End()

--- a/Internal/UI/ColorPicker.lua
+++ b/Internal/UI/ColorPicker.lua
@@ -276,7 +276,7 @@ function ColorPicker.Begin(Options)
 		CurrentColor[1] = Options.Color[1]
 		CurrentColor[2] = Options.Color[2]
 		CurrentColor[3] = Options.Color[3]
-		CurrentColor[4] = Options.Color[4]
+		CurrentColor[4] = Options.Color[4] or 1
 		UpdateSaturationColors()
 	end
 
@@ -384,7 +384,7 @@ function ColorPicker.Begin(Options)
 		local A = 1.0 - CurrentColor[4]
 		local AlphaY = A * AlphaH
 		DrawCommands.Line(X, Y + AlphaY, X + AlphaW, Y + AlphaY, 2.0, {A, A, A, 1.0})
-		
+
 		Y = Y + AlphaH + Cursor.PadY()
 	end
 

--- a/Internal/UI/ColorPicker.lua
+++ b/Internal/UI/ColorPicker.lua
@@ -462,15 +462,15 @@ function ColorPicker.Begin(Options)
 	Cursor.NewLine()
 
 	LayoutManager.Begin('ColorPicker_Buttons_Layout', {AlignX = 'right'})
-	local Result = {Button = "", Color = Utility.MakeColor(CurrentColor)}
+	local Result = {Button = false, Color = Utility.MakeColor(CurrentColor)}
 	if Button.Begin("OK") then
-		Result.Button = "OK"
+		Result.Button = true
 	end
 
 	LayoutManager.SameLine()
 
 	if Button.Begin("Cancel") then
-		Result.Button = "Cancel"
+		Result.Button = false
 		Result.Color = Utility.MakeColor(Options.Color)
 	end
 	LayoutManager.End()

--- a/main.lua
+++ b/main.lua
@@ -27,6 +27,18 @@ SOFTWARE.
 local Slab = require 'Slab'
 local SlabTest = require 'SlabTest'
 
+local props = {
+	{ID = "a", Value = 1},
+	{ID = "b", Value = "test"},
+	{ID = "c", Value = true},
+}
+local common = {
+	a = {
+		MinNumber = 0,
+		MaxNumber = 10,
+	},
+}
+
 function love.load(args)
 	love.graphics.setBackgroundColor(0.07, 0.07, 0.07)
 	Slab.Initialize(args)
@@ -34,7 +46,9 @@ end
 
 function love.update(dt)
 	Slab.Update(dt)
-	SlabTest.Begin()
+	Slab.BeginWindow("test", {Title = "Test"})
+	Slab.Properties(props, common)
+	Slab.EndWindow()
 end
 
 function love.draw()


### PR DESCRIPTION
This is useful for those who don't want to pass any 4th value (alpha) to the `Color` parameter. 

I've encountered something weird:
in testing outside of my project (using Slab's own main.lua):
```lua
local color = {1, 1, 1} --no alpha

--in update
Slab.ColorPicker({Color = color}) -- no error
```

But in my project, the same thing is done:
```lua
local color = e.color.color -- a table of {1, 1, 1}
Slab.ColorPicker({Color = color}) -- gives error (ColorPicker.lua line 384) about a `nil` value, I assume the `CurrentColor[4]`
```

This PR fixes those.