### PR TITLE
Fix Input args validation and use simpler form

### DIFF
--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -913,28 +913,28 @@ function Input.Begin(Id, Options)
 
 	local StatHandle = Stats.Begin('Input', 'Slab')
 
-	Options = Options == nil and {} or Options
-	Options.Tooltip = Options.Tooltip == nil and "" or Options.Tooltip
+	Options = Options or {}
+	Options.Tooltip = Options.Tooltip or ""
 	Options.ReturnOnText = Options.ReturnOnText == nil and true or Options.ReturnOnText
-	Options.Text = Options.Text == nil and "" or tostring(Options.Text)
+	Options.Text = Options.Text and tostring(Options.Text) or ""
 	Options.TextColor = Options.TextColor
-	Options.BgColor = Options.BgColor == nil and Style.InputBgColor or Options.BgColor
-	Options.SelectColor = Options.SelectColor == nil and Style.InputSelectColor or Options.SelectColor
+	Options.BgColor = Options.BgColor or Style.InputBgColor
+	Options.SelectColor = Options.SelectColor or Style.InputSelectColor
 	Options.SelectOnFocus = Options.SelectOnFocus == nil and true or Options.SelectOnFocus
 	Options.W = Options.W
 	Options.H = Options.H
 	Options.ReadOnly = Options.ReadOnly or false
 	Options.Align = Options.Align
-	Options.Rounding = Options.Rounding == nil and Style.InputBgRounding or Options.Rounding
+	Options.Rounding = Options.Rounding or Style.InputBgRounding
 	Options.MinNumber = Options.MinNumber
 	Options.MaxNumber = Options.MaxNumber
 	Options.MultiLine = Options.MultiLine or false
-	Options.MultiLineW = Options.MultiLineW == nil and huge or Options.MultiLineW
+	Options.MultiLineW = Options.MultiLineW or huge
 	Options.Highlight = Options.Highlight
-	Options.Step = Options.Step == nil and 1.0 or Options.Step
+	Options.Step = Options.Step or 1.0
 	Options.NoDrag = Options.NoDrag or false
 	Options.UseSlider = Options.UseSlider or false
-	Options.Precision = Options.Precision == nil and 3 or math.floor(Utility.Clamp(Options.Precision, 0, 5))
+	Options.Precision = Options.Precision and math.floor(Utility.Clamp(Options.Precision, 0, 5)) or 3
 
 	if type(Options.MinNumber) ~= "number" then
 		Options.MinNumber = nil

--- a/Internal/UI/Input.lua
+++ b/Internal/UI/Input.lua
@@ -917,23 +917,23 @@ function Input.Begin(Id, Options)
 	Options.Tooltip = Options.Tooltip == nil and "" or Options.Tooltip
 	Options.ReturnOnText = Options.ReturnOnText == nil and true or Options.ReturnOnText
 	Options.Text = Options.Text == nil and "" or tostring(Options.Text)
-	Options.TextColor = Options.TextColor == nil and nil or Options.TextColor
+	Options.TextColor = Options.TextColor
 	Options.BgColor = Options.BgColor == nil and Style.InputBgColor or Options.BgColor
 	Options.SelectColor = Options.SelectColor == nil and Style.InputSelectColor or Options.SelectColor
 	Options.SelectOnFocus = Options.SelectOnFocus == nil and true or Options.SelectOnFocus
-	Options.W = Options.W == nil and nil or Options.W
-	Options.H = Options.H == nil and nil or Options.H
-	Options.ReadOnly = Options.ReadOnly == nil and false or Options.ReadOnly
-	Options.Align = Options.Align == nil and nil or Options.Align
+	Options.W = Options.W
+	Options.H = Options.H
+	Options.ReadOnly = Options.ReadOnly or false
+	Options.Align = Options.Align
 	Options.Rounding = Options.Rounding == nil and Style.InputBgRounding or Options.Rounding
-	Options.MinNumber = Options.MinNumber == nil and nil or Options.MinNumber
-	Options.MaxNumber = Options.MaxNumber == nil and nil or Options.MaxNumber
-	Options.MultiLine = Options.MultiLine == nil and false or Options.MultiLine
+	Options.MinNumber = Options.MinNumber
+	Options.MaxNumber = Options.MaxNumber
+	Options.MultiLine = Options.MultiLine or false
 	Options.MultiLineW = Options.MultiLineW == nil and huge or Options.MultiLineW
-	Options.Highlight = Options.Highlight == nil and nil or Options.Highlight
+	Options.Highlight = Options.Highlight
 	Options.Step = Options.Step == nil and 1.0 or Options.Step
-	Options.NoDrag = Options.NoDrag == nil and false or Options.NoDrag
-	Options.UseSlider = Options.UseSlider == nil and false or Options.UseSlider
+	Options.NoDrag = Options.NoDrag or false
+	Options.UseSlider = Options.UseSlider or false
 	Options.Precision = Options.Precision == nil and 3 or math.floor(Utility.Clamp(Options.Precision, 0, 5))
 
 	if type(Options.MinNumber) ~= "number" then


### PR DESCRIPTION
The error checking uses the construction `x == nil and valid_when_nil or x`. But that fails when `valid_when_nil` evaluates to false. Using the simpler construction `x or valid_when_nil` with care around booleans would make it easier to see what validation is being done.

Simplifying fixes these args that were nil, but should be boolean.

Options.ReadOnly
Options.MultiLine
Options.NoDrag
Options.UseSlider
