### PR TITLE
[Mouse] Allow customizing screen to slab transforms

### DIFF
--- a/Internal/Input/Mouse.lua
+++ b/Internal/Input/Mouse.lua
@@ -49,7 +49,12 @@ local MousePressedFn = nil
 local MouseReleasedFn = nil
 local Events = {}
 
+local function TransformPoint(X,Y)
+	return X,Y
+end
+
 local function OnMouseMoved(X, Y, DX, DY, IsTouch)
+	X, Y = TransformPoint(X, Y)
 	State.X = X
 	State.Y = Y
 	State.AsyncDeltaX = State.AsyncDeltaX + DX
@@ -68,6 +73,7 @@ local function PushEvent(Type, X, Y, Button, IsTouch, Presses)
 end
 
 local function OnMousePressed(X, Y, Button, IsTouch, Presses)
+	X, Y = TransformPoint(X, Y)
 	PushEvent(Common.Event.Pressed, X, Y, Button, IsTouch, Presses)
 
 	if MousePressedFn ~= nil then
@@ -76,6 +82,7 @@ local function OnMousePressed(X, Y, Button, IsTouch, Presses)
 end
 
 local function OnMouseReleased(X, Y, Button, IsTouch, Presses)
+	X, Y = TransformPoint(X, Y)
 	PushEvent(Common.Event.Released, X, Y, Button, IsTouch, Presses)
 
 	if MouseReleasedFn ~= nil then
@@ -100,7 +107,9 @@ local function ProcessEvents()
 	Events = {}
 end
 
-function Mouse.Initialize(Args)
+function Mouse.Initialize(TransformPointToSlab, Args)
+	TransformPoint = TransformPointToSlab or TransformPoint
+
 	MouseMovedFn = love.handlers['mousemoved']
 	MousePressedFn = love.handlers['mousepressed']
 	MouseReleasedFn = love.handlers['mousereleased']


### PR DESCRIPTION
Fix #20.

Add function arg to customize screen to slab coordinates.

Improve interoperability with screen resizing libraries by allowing
users to specify a function to transform screen coordinates into game
coordinates.

For example, with Ulydev/push you could do:

    local function get_push_mouse(x,y)
        local new_x,new_y = push:toGame(x,y)
        if new_x and new_y then
            return new_x,new_y
        end
        return x,y
    end
    local game_width, game_height, window_width, window_height = 800, 600, 1920, 1080
    push:setupScreen(game_width, game_height, window_width, window_height)
    Slab.Initialize(get_push_mouse, args)