### PR TITLE
Improved Properties to use ordered table

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -2223,22 +2223,6 @@ function Slab.SetLayoutColumn(Index)
 end
 
 --[[
-	SetNextLayoutColumn
-
-	Sets the current active column to the next column.
-
-	Return: None.
---]]
-function Slab.SetNextLayoutColumn(Columns)
-	-- local current = LayoutManager.GetCurrentColumn()
-	-- local index = current + 1
-	-- if index > Columns then
-	-- 	index = 1
-	-- end
-	-- LayoutManager.SetColumn(index)
-end
-
---[[
 	GetLayoutSize
 
 	Retrieves the size of the active layout. If there are columns, then the size of the column is returned.

--- a/API.lua
+++ b/API.lua
@@ -1482,31 +1482,33 @@ function Slab.Properties(Table, Options, Fallback)
 	Fallback = Fallback or {}
 
 	if Table ~= nil then
-		for K, V in pairs(Table) do
+		for I, T in ipairs(Table) do
+			local V = T.Value
 			local Type = type(V)
-			local ItemOptions = Options[K] or Fallback
+			local ID = T.ID
+			local ItemOptions = Options[ID] or Fallback
 			if Type == "boolean" then
-				if Slab.CheckBox(V, K, ItemOptions) then
-					Table[K] = not Table[K]
+				if Slab.CheckBox(V, ID, ItemOptions) then
+					T.Value = not T.Value
 				end
 			elseif Type == "number" then
-				Slab.Text(K .. ": ")
+				Slab.Text(ID .. ": ")
 				Slab.SameLine()
 				ItemOptions.Text = V
 				ItemOptions.NumbersOnly = true
 				ItemOptions.ReturnOnText = false
 				ItemOptions.UseSlider = ItemOptions.MinNumber and ItemOptions.MaxNumber
-				if Slab.Input(K, ItemOptions) then
-					Table[K] = Slab.GetInputNumber()
+				if Slab.Input(ID, ItemOptions) then
+					T.Value = Slab.GetInputNumber()
 				end
 			elseif Type == "string" then
-				Slab.Text(K .. ": ")
+				Slab.Text(ID .. ": ")
 				Slab.SameLine()
 				ItemOptions.Text = V
 				ItemOptions.NumbersOnly = false
 				ItemOptions.ReturnOnText = false
-				if Slab.Input(K, ItemOptions) then
-					Table[K] = Slab.GetInputText()
+				if Slab.Input(ID, ItemOptions) then
+					T.Value = Slab.GetInputText()
 				end
 			end
 		end
@@ -2218,6 +2220,22 @@ end
 --]]
 function Slab.SetLayoutColumn(Index)
 	LayoutManager.SetColumn(Index)
+end
+
+--[[
+	SetNextLayoutColumn
+
+	Sets the current active column to the next column.
+
+	Return: None.
+--]]
+function Slab.SetNextLayoutColumn(Columns)
+	-- local current = LayoutManager.GetCurrentColumn()
+	-- local index = current + 1
+	-- if index > Columns then
+	-- 	index = 1
+	-- end
+	-- LayoutManager.SetColumn(index)
 end
 
 --[[


### PR DESCRIPTION
Using `key-pair` tables can make the widgets out of order every boot of the project which is not ideal.
Use instead an `ordered` table so orders are kept